### PR TITLE
Remove duplicate method order_column_definitions

### DIFF
--- a/lib/activerecord-clean-db-structure/clean_dump.rb
+++ b/lib/activerecord-clean-db-structure/clean_dump.rb
@@ -180,23 +180,6 @@ module ActiveRecordCleanDbStructure
         end
       end
     end
-    
-    # Orders the columns definitions alphabetically
-    # - ignores quotes which surround column names that are equal to reserved PostgreSQL names.
-    # - keeps the columns at the top and places the constraints at the bottom.
-    def order_column_definitions
-      dump.gsub!(/^(?<table>CREATE TABLE .+?\(\n)(?<columns>.+?)(?=\n\);$)/m) do
-        columns =
-          $~[:columns]
-          .split(",\n")
-          .sort_by { |column| column[/[^ "]+/] }
-          .partition { |column| !column.match?(/\A *CONSTRAINT/) }
-          .flatten
-          .join(",\n")
-
-        [$~[:table], columns].join
-      end
-    end
 
     # Moves the separate unique constraint statements to the create table statements.
     def move_unique_constraints


### PR DESCRIPTION
Hi, your fork seems to be one of the better maintained/more complete ones. Do you accept PRs? Here is a straightforward one (that isn't relevant to the original repo.)
